### PR TITLE
Feat/cafe detail page

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -7,6 +7,9 @@
 
 # The following line activates a set of recommended lints for Flutter apps,
 # packages, and plugins designed to encourage good coding practices.
+analyzer:
+  errors:
+    empty_catches: ignore
 include: package:flutter_lints/flutter.yaml
 
 linter:
@@ -21,8 +24,9 @@ linter:
   # `// ignore_for_file: name_of_lint` syntax on the line or in the file
   # producing the lint.
   rules:
+    prefer_const_constructors: false
+    prefer_const_literals_to_create_immutables: false
     # avoid_print: false  # Uncomment to disable the `avoid_print` rule
     # prefer_single_quotes: true  # Uncomment to enable the `prefer_single_quotes` rule
-
 # Additional information about this file can be found at
 # https://dart.dev/guides/language/analysis-options

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1234,6 +1234,8 @@ PODS:
   - flutter_naver_map (1.3.0):
     - Flutter
     - NMapsMap (= 3.19.0)
+  - geolocator_apple (1.2.0):
+    - Flutter
   - google_sign_in_ios (0.0.1):
     - AppAuth (>= 1.7.4)
     - Flutter
@@ -1391,6 +1393,7 @@ DEPENDENCIES:
   - firebase_storage (from `.symlinks/plugins/firebase_storage/ios`)
   - Flutter (from `Flutter`)
   - flutter_naver_map (from `.symlinks/plugins/flutter_naver_map/ios`)
+  - geolocator_apple (from `.symlinks/plugins/geolocator_apple/ios`)
   - google_sign_in_ios (from `.symlinks/plugins/google_sign_in_ios/darwin`)
   - image_picker_ios (from `.symlinks/plugins/image_picker_ios/ios`)
   - kakao_flutter_sdk_common (from `.symlinks/plugins/kakao_flutter_sdk_common/ios`)
@@ -1438,6 +1441,8 @@ EXTERNAL SOURCES:
     :path: Flutter
   flutter_naver_map:
     :path: ".symlinks/plugins/flutter_naver_map/ios"
+  geolocator_apple:
+    :path: ".symlinks/plugins/geolocator_apple/ios"
   google_sign_in_ios:
     :path: ".symlinks/plugins/google_sign_in_ios/darwin"
   image_picker_ios:
@@ -1470,6 +1475,7 @@ SPEC CHECKSUMS:
   FirebaseStorage: 52fb65a69d3e87675186881a08e2a5db86452ace
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
   flutter_naver_map: b7ccf21ee350a34381ec92d0bfdad1e8714af9bc
+  geolocator_apple: 1560c3c875af2a412242c7a923e15d0d401966ff
   google_sign_in_ios: 0ab078e60da6dfe23cbc55c83502b52bba1aad63
   GoogleSignIn: d4281ab6cf21542b1cfaff85c191f230b399d2db
   GoogleUtilities: 26a3abef001b6533cf678d3eb38fd3f614b7872d

--- a/lib/constant/theme.dart
+++ b/lib/constant/theme.dart
@@ -7,5 +7,4 @@ class CustomColors {
   static const Color lightGray = Color(0xFFD9D9D9);
   static const Color brown = Color(0xFFA47764);
   static const Color onError = Color(0xFFFD7563);
-  static const Color blue = Color.fromRGBO(58, 120, 243, 1);
 }

--- a/lib/core/feed_detail_page.dart
+++ b/lib/core/feed_detail_page.dart
@@ -80,7 +80,6 @@ class _FeedDetailPageState extends State<FeedDetailPage> {
           return Column(
             children: [
               FeedInfo(feed: widget.feed),
-              const SizedBox(height: 12),
               FeedContent(feed: widget.feed),
             ],
           );

--- a/lib/core/widgets/feed_content.dart
+++ b/lib/core/widgets/feed_content.dart
@@ -17,6 +17,7 @@ class FeedContent extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
+        SizedBox(height: 12),
         Container(
           width: double.infinity,
           height: MediaQuery.of(context).size.width,

--- a/lib/core/widgets/feed_info.dart
+++ b/lib/core/widgets/feed_info.dart
@@ -1,8 +1,10 @@
 import 'package:bean_tripper/constant/theme.dart';
 import 'package:bean_tripper/domain/entity/feed.dart';
+import 'package:bean_tripper/presentation/pages/cafe_detail/cafe_detail_view_model.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-class FeedInfo extends StatelessWidget {
+class FeedInfo extends ConsumerWidget {
   final Feed feed;
 
   const FeedInfo({
@@ -11,7 +13,7 @@ class FeedInfo extends StatelessWidget {
   });
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 20),
       child: Row(
@@ -31,7 +33,7 @@ class FeedInfo extends StatelessWidget {
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               Text(
-                feed.writerName, // 수정: writerName 사용
+                feed.writerName,
                 style: TextStyle(fontWeight: FontWeight.bold),
               ),
               Text(
@@ -41,7 +43,17 @@ class FeedInfo extends StatelessWidget {
             ],
           ),
           Spacer(),
-          Icon(Icons.arrow_forward),
+          GestureDetector(
+            onTap: () {
+              final viewModel = ref.read(cafeDetailViewModelProvider.notifier);
+              viewModel.setCafeName(feed.cafeName);
+              Navigator.pushNamed(
+                context,
+                '/cafe_detail_page',
+              );
+            },
+            child: Icon(Icons.arrow_forward),
+          ),
         ],
       ),
     );

--- a/lib/presentation/pages/cafe_detail/cafe_detail_page.dart
+++ b/lib/presentation/pages/cafe_detail/cafe_detail_page.dart
@@ -14,16 +14,23 @@ class CafeDetailPage extends ConsumerWidget {
     final state = ref.watch(cafeDetailViewModelProvider);
     final viewModel = ref.read(cafeDetailViewModelProvider.notifier);
 
+    if (state.isLoading) {
+      return const Scaffold(
+        body: Center(
+          child: CircularProgressIndicator(),
+        ),
+      );
+    }
+
     return Scaffold(
       appBar: AppBar(
-        title: Text(state.cafeDetail?.name ?? '카페 상세'),
+        title: Text(state.cafeDetail!.name),
         actions: [
           Row(
             children: [
               GestureDetector(
                 onTap: () async {
                   if (FirebaseAuth.instance.currentUser == null) {
-                    // 로그인되지 않은 경우 처리
                     ScaffoldMessenger.of(context).showSnackBar(
                       const SnackBar(content: Text('로그인이 필요한 기능입니다.')),
                     );

--- a/lib/presentation/pages/cafe_detail/cafe_detail_view_model.dart
+++ b/lib/presentation/pages/cafe_detail/cafe_detail_view_model.dart
@@ -52,18 +52,25 @@ class CafeDetailViewModel extends StateNotifier<CafeDetailState> {
   Future<void> checkFavoriteStatus(String cafeName) async {
     try {
       final userId = _auth.currentUser?.uid;
-      if (userId == null) return;
+      if (userId == null) {
+        state = state.copyWith(isFavorite: false);
+        return;
+      }
 
-      final docSnapshot = await _firestore
-          .collection('users')
+      final favoritesSnapshot = await _firestore
+          .collection('user')
           .doc(userId)
           .collection('favoriteCafe')
-          .where('cafeName', isEqualTo: cafeName)
           .get();
 
-      state = state.copyWith(isFavorite: docSnapshot.docs.isNotEmpty);
+      final isFavorite = favoritesSnapshot.docs.any((doc) {
+        final data = doc.data();
+        return data['cafeName'] == cafeName;
+      });
+
+      state = state.copyWith(isFavorite: isFavorite);
     } catch (e) {
-      print('Error checking favorite status: $e');
+      state = state.copyWith(isFavorite: false);
     }
   }
 
@@ -75,19 +82,19 @@ class CafeDetailViewModel extends StateNotifier<CafeDetailState> {
       if (userId == null || cafeName == null) return;
 
       final userFavoriteRef =
-          _firestore.collection('users').doc(userId).collection('favoriteCafe');
+          _firestore.collection('user').doc(userId).collection('favoriteCafe');
 
       if (state.isFavorite) {
-        final querySnapshot =
-            await userFavoriteRef.where('cafeName', isEqualTo: cafeName).get();
+        final favoritesSnapshot = await userFavoriteRef.get();
+        final docToDelete = favoritesSnapshot.docs.firstWhere(
+          (doc) => doc.data()['cafeName'] == cafeName,
+          orElse: () => throw Exception('Document not found'),
+        );
 
-        for (var doc in querySnapshot.docs) {
-          await doc.reference.delete();
-        }
+        await userFavoriteRef.doc(docToDelete.id).delete();
       } else {
-        await userFavoriteRef.add({
+        final docRef = await userFavoriteRef.add({
           'cafeName': cafeName,
-          'timestamp': FieldValue.serverTimestamp(),
         });
       }
 
@@ -132,6 +139,8 @@ class CafeDetailViewModel extends StateNotifier<CafeDetailState> {
       final doc = snapshot.docs.first;
       final cafeId = doc.id;
       await fetchCafeDetail(cafeId);
+
+      await checkFavoriteStatus(cafeName);
     } catch (e) {
       print('Error in initWithCafeName: $e');
     }

--- a/lib/presentation/pages/cafe_detail/cafe_detail_view_model.dart
+++ b/lib/presentation/pages/cafe_detail/cafe_detail_view_model.dart
@@ -34,26 +34,19 @@ class CafeDetailState {
 }
 
 class CafeDetailViewModel extends StateNotifier<CafeDetailState> {
-  final FetchCafeItemUsecase _fetchCafeItemUsecase;
   final FirebaseFirestore _firestore = FirebaseFirestore.instance;
   final FirebaseAuth _auth = FirebaseAuth.instance;
+  String? _cafeName;
 
-  CafeDetailViewModel(this._fetchCafeItemUsecase) : super(CafeDetailState()) {
-    _initFirstCafe();
+  CafeDetailViewModel(FetchCafeItemUsecase watch) : super(CafeDetailState()) {
+    if (_cafeName != null) {
+      initWithCafeName(_cafeName!);
+    }
   }
 
-  Future<void> _initFirstCafe() async {
-    try {
-      final snapshot = await _firestore.collection('cafe').limit(1).get();
-      if (snapshot.docs.isNotEmpty) {
-        final firstCafeId = snapshot.docs[0].id;
-        await fetchCafeDetail(firstCafeId);
-      } else {}
-    } catch (e) {
-      state = state.copyWith(
-        error: '카페 정보를 불러오는데 실패했습니다.',
-      );
-    }
+  void setCafeName(String name) {
+    _cafeName = name;
+    initWithCafeName(name);
   }
 
   Future<void> checkFavoriteStatus(String cafeName) async {
@@ -99,33 +92,48 @@ class CafeDetailViewModel extends StateNotifier<CafeDetailState> {
       }
 
       state = state.copyWith(isFavorite: !state.isFavorite);
-    } catch (e) {
-      print('Error toggling favorite: $e');
-    }
+    } catch (e) {}
   }
 
   Future<void> fetchCafeDetail(String cafeId) async {
     try {
-      state = state.copyWith(isLoading: true, error: null);
-      final cafeDetail = await _fetchCafeItemUsecase.excute(cafeId);
+      final docSnapshot = await _firestore.collection('cafe').doc(cafeId).get();
+      final data = docSnapshot.data()!;
 
-      if (cafeDetail != null) {
-        state = state.copyWith(
-          isLoading: false,
-          cafeDetail: cafeDetail,
-        );
-        await checkFavoriteStatus(cafeDetail.name);
-      } else {
-        state = state.copyWith(
-          isLoading: false,
-          error: '카페 정보를 찾을 수 없습니다.',
-        );
-      }
-    } catch (e) {
+      final cafeDetail = CafeDetail(
+        id: docSnapshot.id,
+        name: data['name'] ?? '',
+        address: data['address'] ?? '',
+        lat: (data['lat'] ?? 0.0).toDouble(),
+        lng: (data['lng'] ?? 0.0).toDouble(),
+        tel: data['tel'],
+        feedImageUrls: data['feedImageUrls'],
+      );
+
       state = state.copyWith(
         isLoading: false,
-        error: '카페 정보를 불러오는데 실패했습니다.',
+        cafeDetail: cafeDetail,
       );
+      await checkFavoriteStatus(cafeDetail.name);
+    } catch (e) {
+      print('Error in fetchCafeDetail: $e');
+    }
+  }
+
+  Future<void> initWithCafeName(String cafeName) async {
+    try {
+      state = state.copyWith(isLoading: true);
+
+      final snapshot = await _firestore
+          .collection('cafe')
+          .where('name', isEqualTo: cafeName)
+          .get();
+
+      final doc = snapshot.docs.first;
+      final cafeId = doc.id;
+      await fetchCafeDetail(cafeId);
+    } catch (e) {
+      print('Error in initWithCafeName: $e');
     }
   }
 

--- a/lib/presentation/pages/cafe_detail/widgets/cafe_info.dart
+++ b/lib/presentation/pages/cafe_detail/widgets/cafe_info.dart
@@ -22,14 +22,14 @@ class CafeInfo extends ConsumerWidget {
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 Text(
-                  cafeDetail?.address ?? '주소 정보 없음',
+                  cafeDetail?.address ?? '주소 정보가 없습니다',
                   style: TextStyle(fontSize: 16),
                 ),
                 Row(
                   children: [
                     Icon(Icons.local_phone),
                     SizedBox(width: 6),
-                    Text(cafeDetail?.tel ?? '전화번호 정보 없음'),
+                    Text(cafeDetail?.tel ?? '전화번호 정보가 없습니다'),
                   ],
                 )
               ],


### PR DESCRIPTION
<변경사항>
1. feed_page에서 cafeName넘겨줘서 cafe_detail_page에 해당 카페에 해당하는 정보 및 피드만 보여주기
2. cafe_detail_page 좋아요 기능 추가

10일(금) 오전스크럼에서 얘기 할 사항(현주님이 머지하면서 이거 뭐냐고하면 기억나겠지...?)
1. 고은님: 글 작성 시 feed_page로 네비게이트 하셨는지?, 글 작성 시 userID가 같이 기록되어야함(feed에서 닉네임/프로필에서 닉네임 및 내가 작성한 피드보여줄 때 필요)
2. 채은님: 피드 오늘의카페도 같이 리스트뷰에 담겨서 스크롤 시 올라가야함, 어제 말했던 피드페이지에서는 작성 순서대로 모두 보여주고, cafe_detail_page에서 카페ID와 피드 문서ID.Index값을 받으면 해당 카페에대한 피드들을 띄운다음에 문서ID의 인덱스를 보여줘야함.(만약 3의 인덱스를 받으면 4번째 피드가 보이고 스크롤을 올리면 0-3, 내리면 다음 피드들이 보여야됨), 피드 작성 후 피드페이지 오면 화면 업데이트 해줘야됨
3. 현주님: 맵페이지로 Id, lat, lng보냈으니 해당 값들을 참고해서 위치 및 마커를 보여줘야됨/(단, 피드페이지 앱바에서 아이콘을 타고 들어갔을 때는 내 위치를 기준으로 보여주거나 아무위치 보여주고 gps버튼 클릭 시 현위치 보여주도록해야됨.)
4. 진용님: 피드 및 프로필에 실명을 보여줄 수 는 없으니 닉네임 설정하는 회원가입페이지 필요!(혹시 실명제 원하시면 그냥 실명제로해도 되기는함)
